### PR TITLE
Build packages on GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: release
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        target:
+          - x86_64-apple-darwin
+          - x86_64-unknown-linux-gnu
+          # NOTE: the build failed on CI
+          # - x86_64-pc-windows-gnu
+        include:
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          # - target: x86_64-pc-windows-gnu
+          #   os: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # https://github.com/actions/cache/blob/master/examples.md#rust---cargo
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      # build
+      - uses: actions-rs/cargo@v1
+        env:
+          X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR: /usr/lib/x86_64-linux-gnu/
+          X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR: /usr/include/openssl/
+        with:
+          command: build
+          args: --release --target ${{ matrix.target }}
+
+      # archive and upload
+      - run: |
+          zip --junk-paths miteras-${{ matrix.target }}.zip target/${{ matrix.target }}/release/miteras{,.exe}
+      - uses: actions/upload-artifact@v1
+        with:
+          name: build-${{ matrix.target }}.zip
+          path: miteras-${{ matrix.target }}.zip
+
+  release:
+    needs: [build]
+    if: github.ref != 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      # download zip files
+      - uses: actions/download-artifact@v1
+        with:
+          name: build-x86_64-apple-darwin.zip
+      - uses: actions/download-artifact@v1
+        with:
+          name: build-x86_64-unknown-linux-gnu.zip
+
+      # create release
+      - id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+
+      # upload zip files
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./build-x86_64-apple-darwin.zip
+          asset_name: build-x86_64-apple-darwin.zip
+          asset_content_type: application/zip
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./build-x86_64-unknown-linux-gnu.zip
+          asset_name: build-x86_64-unknown-linux-gnu.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
Automatically create releases on GitHub Actions so users can easily donload `miteras-cli`.

## See Also

- https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
- https://motemen.hatenablog.com/entry/2019/11/github-actions-crossbuild-rust